### PR TITLE
Bug fix: racing cond during insolation update

### DIFF
--- a/src/forcing_module.f90
+++ b/src/forcing_module.f90
@@ -802,20 +802,19 @@ CONTAINS
     time_applied = 0._dp
 
     IF     (C%choice_insolation_forcing == 'none') THEN
-      IF (par%master) WRITE(0,*) 'get_insolation_at_time - ERROR: choice_insolation_forcing = "none"!'
-      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+      CALL crash('insolation should not be used when choice_insolation_forcing = "none"!')
     ELSEIF (C%choice_insolation_forcing == 'static') THEN
       time_applied = C%static_insolation_time
     ELSEIF (C%choice_insolation_forcing == 'realistic') THEN
       time_applied = time
     ELSE
-      IF (par%master) WRITE(0,*) 'get_insolation_at_time - ERROR: unknown choice_insolation_forcing "', TRIM( C%choice_insolation_forcing), '"!'
-      CALL MPI_ABORT( MPI_COMM_WORLD, cerr, ierr)
+      CALL crash('unknown choice_insolation_forcing "' // TRIM( C%choice_insolation_forcing) // '"!')
     END IF
 
     ! Check if the requested time is enveloped by the two timeframes;
     ! if not, read the two relevant timeframes from the NetCDF file
     IF (time_applied < forcing%ins_t0 .OR. time_applied > forcing%ins_t1) THEN
+      CALL sync
       CALL update_insolation_timeframes_from_file( time_applied)
     END IF
 
@@ -892,6 +891,7 @@ CONTAINS
     ! Check if the requested time is enveloped by the two timeframes;
     ! if not, read the two relevant timeframes from the NetCDF file
     IF (time_applied < forcing%ins_t0 .AND. time_applied > forcing%ins_t1) THEN
+      CALL sync
       CALL update_insolation_timeframes_from_file( time_applied)
     END IF
 

--- a/src/general_ice_model_data_module.f90
+++ b/src/general_ice_model_data_module.f90
@@ -1069,7 +1069,7 @@ CONTAINS
       ! Compile list of ice-front pixels and their basin ID's
       IF (par%master) THEN
         n_front = 0
-        DO vi = mesh%vi1, mesh%vi2
+        DO vi = 1, mesh%nV
           IF (basin_ID_loc( vi) > 0) THEN
             ! Check if any connected vertex doesn't have a basin ID yet
             ! (trimming triling 0s in mesh%C)
@@ -1085,7 +1085,7 @@ CONTAINS
 
       IF (par%master) THEN
         k = 0
-        DO vi = mesh%vi1, mesh%vi2
+        DO vi = 1, mesh%nV
           IF (basin_ID_loc( vi) > 0) THEN
             IF (MINVAL( basin_ID_loc( mesh%C(vi,1:mesh%nC(vi)))) == 0) THEN
               k = k + 1


### PR DESCRIPTION
The routine get_insolation_at_time had an issue where the model would
randomly freeze during a call to update_insolation_timeframes_from_file.
Basically a racing condition between the master and the other processes.
Fixed by calling sync before the update. Same for the legacy routine
get_insolation_at_time_month_and_lat, just in case.

Bonus: fixed a bug in general_ice_model_data_module.f90, during basins
definition/extrapolation, where the master should loop over the entire
mesh, but it was doing it only over its partitioned sub-domain.