### PR TITLE
Add exception: regional text output only for IMAU-ITM

### DIFF
--- a/config-files/config_test
+++ b/config-files/config_test
@@ -6,13 +6,13 @@
   start_time_of_run_config                    = 1900.0                           ! Start time (in years) of the simulations
   end_time_of_run_config                      = 2300.0                           ! End   time (in years) of the simulations
   dt_coupling_config                          = 100.0                            ! Interval of coupling (in years) between the four ice-sheets
-  dt_max_config                               = 2.0                              ! Maximum time step (in years) of the ice model
-  dt_thermo_config                            = 2.0                              ! Time step (in years) for updating thermodynamics
-  dt_climate_config                           = 10.0                             ! Time step (in years) for updating the climate
-  dt_ocean_config                             = 10.0                             ! Time step (in years) for updating the ocean
-  dt_SMB_config                               = 2.0                              ! Time step (in years) for updating the SMB
-  dt_BMB_config                               = 2.0                              ! Time step (in years) for updating the BMB
-  dt_output_config                            = 10.0                             ! Time step (in years) for writing output
+  dt_max_config                               = 1.0                              ! Maximum time step (in years) of the ice model
+  dt_thermo_config                            = 1.0                              ! Time step (in years) for updating thermodynamics
+  dt_climate_config                           = 1.0                             ! Time step (in years) for updating the climate
+  dt_ocean_config                             = 1.0                             ! Time step (in years) for updating the ocean
+  dt_SMB_config                               = 1.0                              ! Time step (in years) for updating the SMB
+  dt_BMB_config                               = 1.0                              ! Time step (in years) for updating the BMB
+  dt_output_config                            = 1.0                             ! Time step (in years) for writing output
   dt_mesh_min_config                          = 50.0                             ! Minimum amount of time (in years) between mesh updates
   dt_bedrock_ELRA_config                      = 100.0                            ! Time step (in years) for updating the bedrock deformation rate with the ELRA model
   dt_SELEN_config                             = 1000.0                           ! Time step (in years) for calling SELEN
@@ -151,7 +151,7 @@
   filename_geothermal_heat_flux_config        = 'data/GHF/geothermal_heatflux_ShapiroRitzwoller2004_global_1x1_deg.nc'
 
   ! Parameters for calculating modelled benthic d18O
-  do_calculate_benthic_d18O_config            = .TRUE.                           ! Whether or not to calculate modelled benthic d18O (set to .FALSE. for e.g. idealised-geometry experiments, future projections)
+  do_calculate_benthic_d18O_config            = .FALSE.                          ! Whether or not to calculate modelled benthic d18O (set to .FALSE. for e.g. idealised, future projections, ISMIP6)
 
   ! Ice dynamics - time integration
   ! ===============================
@@ -219,7 +219,7 @@
     choice_calving_law_config                 = 'threshold_thickness'            ! Choice of calving law: "none", "threshold_thickness"
     calving_threshold_thickness_shelf_config  = 100.0                            ! Threshold ice thickness for ice shelf calving front in the "threshold_thickness" calving law
     calving_threshold_thickness_sheet_config  = 0.0                              ! Threshold ice thickness for ice sheet calving front in the "threshold_thickness" calving law
-    max_calving_rounds_config                 = 10                               ! Maximum number of calving loops during chain reaction
+    max_calving_rounds_config                 = 5                                ! Maximum number of calving loops during chain reaction
     do_remove_shelves_config                  = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
     remove_shelves_larger_than_PD_config      = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
     continental_shelf_calving_config          = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
@@ -276,7 +276,7 @@
   ! Surface mass balance
   ! ====================
 
-  choice_SMB_model_config                     = 'IMAU-ITM'                       ! Choice of SMB model: "uniform", "idealised", "IMAU-ITM", "direct_global", "direct_regional"
+  choice_SMB_model_config                     = 'ISMIP_style_forcing'            ! Choice of SMB model: "uniform", "idealised", "IMAU-ITM", "direct_global", "direct_regional"
   SMB_uniform_config                          = 0.0                              ! Uniform SMB, applied when choice_SMB_model = "uniform" [mie/yr]
 
   ! Firn layer
@@ -407,13 +407,13 @@
   help_field_13_config                        = 'uabs_surf'
   help_field_14_config                        = 'uabs_base'
   help_field_15_config                        = 'T2m_year'
-  help_field_16_config                        = 'Precip_year'
-  help_field_17_config                        = 'Rainfall_year'
-  help_field_18_config                        = 'Snowfall_year'
-  help_field_19_config                        = 'Albedo_year'
-  help_field_20_config                        = 'Melt_year'
-  help_field_21_config                        = 'Refreezing_year'
-  help_field_22_config                        = 'Runoff_year'
+  !help_field_16_config                        = 'Precip_year'
+  !help_field_17_config                        = 'Rainfall_year'
+  !help_field_18_config                        = 'Snowfall_year'
+  !help_field_19_config                        = 'Albedo_year'
+  !help_field_20_config                        = 'Melt_year'
+  !help_field_21_config                        = 'Refreezing_year'
+  !help_field_22_config                        = 'Runoff_year'
   help_field_23_config                        = 'SMB_year'
   help_field_24_config                        = 'SL'
 

--- a/src/UFEMISM_main_model.f90
+++ b/src/UFEMISM_main_model.f90
@@ -233,8 +233,10 @@ CONTAINS
       IF (region%do_output .OR. region%do_SMB .OR. region%do_BMB) THEN
         ! Determine total ice sheet area, volume, and volume-above-flotation,
         CALL calculate_icesheet_volume_and_area( region)
-        ! Write to regional text output file
-        CALL write_regional_text_output( region)
+        IF (C%choice_SMB_model == 'IMAU-ITM') THEN
+          ! Write to regional text output file
+          CALL write_regional_text_output( region)
+        END IF
       END IF
 
       ! == Update ice geometry
@@ -264,7 +266,9 @@ CONTAINS
         region%output_file_exists = .TRUE.
       END IF
       CALL write_to_output_files( region)
-      CALL write_regional_text_output( region)
+      IF (C%choice_SMB_model == 'IMAU-ITM') THEN
+        CALL write_regional_text_output( region)
+      END IF
     END IF
 
     ! Determine total ice sheet area, volume, volume-above-flotation and GMSL contribution,


### PR DESCRIPTION
Since this old text thing requires variables that are not always
initialised when using other SMB methods, added an exception to
output these vars only when the IMAU-ITM model is used. NetCDF
output needed to solve all these issues!